### PR TITLE
explicitly require home controller file 

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -10,7 +10,7 @@ var passportOptions = {
 }
 
 // controllers
-var home = require('home')
+var home = require('../app/controllers/home')
 
 /**
  * Expose


### PR DESCRIPTION
Ran into the following error, 

```
node server.js

module.js:340
    throw err;
          ^
Error: Cannot find module 'home'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/weston/git/node-express-mongoose/config/routes.js:13:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

Therefore, specified the path for the required file.

When I tried this with NPM, I did not get an error. Is this a change that should be made?
