### PR TITLE
model/*.js.swp files no longer load.

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,19 @@
 
 require('dotenv').config();
 
+/**
+ * Gets the index of a regex in a string. If not found, returns -1.
+ * @param {Regex} regex A regular expression
+ * @param {number} startpos The starting position in the string for
+ *                 conducting the search
+ * @return {number} The position where the regex begins
+ */
+
+String.prototype.regexIndexOf = function(regex, startpos) {
+  var indexOf = this.substring(startpos || 0).search(regex);
+  return (indexOf >= 0) ? (indexOf + (startpos || 0)) : indexOf;
+};
+
 const fs = require('fs');
 const join = require('path').join;
 const express = require('express');
@@ -36,7 +49,7 @@ module.exports = {
 
 // Bootstrap models
 fs.readdirSync(models)
-  .filter(file => ~file.indexOf('.js'))
+  .filter(file => ~file.regexIndexOf(/.js$/))
   .forEach(file => require(join(models, file)));
 
 // Bootstrap routes


### PR DESCRIPTION
The server crashes when it tries to load .js.swp files (aka. whenever you have a model opened in vim)

The placement of regexIndexOf isn't great, but this solution fixes it. Feel free to refactor on top of this or recommend me to make an improvement for me.
